### PR TITLE
Fix Uwp Image support

### DIFF
--- a/src/HotUI.UWP/Controls/HUIListCell.cs
+++ b/src/HotUI.UWP/Controls/HUIListCell.cs
@@ -29,14 +29,26 @@ namespace HotUI.UWP
                 if (_handler is ViewHandler oldViewHandler)
                     oldViewHandler.NativeViewChanged -= HandleNativeViewChanged;
 
+                if (_view != null)
+                    _view.NeedsLayout -= LayoutChanged;
+
                 _view = value;
                 _handler = _view?.ViewHandler;
+
+                if (_view != null)
+                    _view.NeedsLayout += LayoutChanged;
 
                 if (_handler is ViewHandler newViewHandler)
                     newViewHandler.NativeViewChanged += HandleNativeViewChanged;
 
                 HandleNativeViewChanged(this, null);
             }
+        }
+
+        private void LayoutChanged(object sender, EventArgs e)
+        {
+            InvalidateMeasure();
+            InvalidateArrange();
         }
 
         private void HandleNativeViewChanged(object sender, ViewChangedEventArgs e)

--- a/src/HotUI.UWP/Handlers/AbstractHandler.cs
+++ b/src/HotUI.UWP/Handlers/AbstractHandler.cs
@@ -71,7 +71,8 @@ namespace HotUI.UWP.Handlers
         
         public virtual SizeF Measure(SizeF availableSize)
         {
-            return availableSize;
+            _nativeView.Measure(availableSize.ToSize());
+            return _nativeView.DesiredSize.ToSizeF();
         }
 
         public void SetFrame(RectangleF frame)

--- a/src/HotUI.UWP/Handlers/ImageHandler.cs
+++ b/src/HotUI.UWP/Handlers/ImageHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Media.Imaging;
+﻿using Windows.UI.Xaml.Media;
 using UWPImage = Windows.UI.Xaml.Controls.Image;
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable ClassNeverInstantiated.Global
@@ -14,8 +11,6 @@ namespace HotUI.UWP.Handlers
         {
             [nameof(Image.Bitmap)] = MapBitmapProperty
         };
-
-        internal string CurrentSource;
 
         public ImageHandler() : base(Mapper)
         {
@@ -35,16 +30,9 @@ namespace HotUI.UWP.Handlers
         public static void MapBitmapProperty(IViewHandler viewHandler, Image virtualView)
         {
             var imageHandler = (ImageHandler)viewHandler;
-            try
-            {
-                var bitmap = virtualView.Bitmap;
-                var source = 
-                imageHandler.TypedNativeView.Source = bitmap.NativeBitmap as ImageSource;
-            }
-            catch (Exception e)
-            {
-                Debug.WriteLine(e);
-            }
+            var bitmap = virtualView.Bitmap;
+            var nativeBitmap = (ImageSource)bitmap?.NativeBitmap;
+            imageHandler.TypedNativeView.Source = nativeBitmap;
             virtualView.InvalidateMeasurement();
         }
     }

--- a/src/HotUI/Controls/View.cs
+++ b/src/HotUI/Controls/View.cs
@@ -382,6 +382,10 @@ namespace HotUI
         public void InvalidateMeasurement()
         {
             MeasurementValid = false;
+
+            // TODO We should "invalidate" layout here. Close enough for now?
+            frame = RectangleF.Zero;
+
             Parent?.InvalidateMeasurement();
             NeedsLayout?.Invoke(this, EventArgs.Empty);
         }

--- a/src/HotUI/Internal/ReflectionExtensions.cs
+++ b/src/HotUI/Internal/ReflectionExtensions.cs
@@ -33,7 +33,7 @@ namespace HotUI.Reflection
             if (obj == null)
                 return null;
             var newType = obj.GetType();
-            if (newType == type)
+            if (type.IsAssignableFrom(newType))
                 return obj;
             //if (type == typeof(String))
             //    return obj.ToString();


### PR DESCRIPTION
ReflectionExtensions.Convert - Do not attempt to convert subclasses. For example, don't try to convert UwpBitmap to Bitmap, because it's already a Bitmap.

View - "Invalidate" layout on measure invalid
HUIListCell - Invalidate underlying native control layout/arrange on NeedsLayout
Uwp AbstractHandler - Call measure on underlying platform control
Uwp ImageHandler - Simplify